### PR TITLE
fix: webpack 의 결과물을 admin/main 으로 나눈다

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,20 +1,20 @@
-const { CleanWebpackPlugin } = require("clean-webpack-plugin");
-const HtmlWebpackPlugin = require("html-webpack-plugin");
-const path = require("path");
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const path = require('path');
 
 module.exports = {
-  mode: "development",
+  mode: 'development',
   resolve: {
-    extensions: [".js", ".jsx"],
+    extensions: ['.js', '.jsx'],
   },
   entry: {
-    main: "./src/index.jsx",
-    admin: "./src/admin/index.jsx",
+    main: './src/index.jsx',
+    admin: './src/admin/index.jsx',
   },
   output: {
-    path: path.resolve(__dirname, "/dist"),
-    filename: "bundle.js",
-    publicPath: "/",
+    path: path.resolve(__dirname, 'dist'),
+    filename: '[name].bundle.js',
+    publicPath: '/',
   },
   module: {
     rules: [
@@ -23,21 +23,20 @@ module.exports = {
         exclude: /node_modules/,
         use: [
           {
-            loader: "babel-loader",
+            loader: 'babel-loader',
           },
         ],
       },
       {
         test: /\.(png|jpe?g|gif)$/i,
-        loader: "file-loader",
+        loader: 'file-loader',
         options: {
-          name: "[name].[ext]",
+          name: '[name].[ext]',
         },
       },
       {
         test: /.css$/,
-        exclude: [],
-        use: ["style-loader", "css-loader", "postcss-loader"],
+        use: ['style-loader', 'css-loader', 'postcss-loader'],
       },
     ],
   },
@@ -47,8 +46,16 @@ module.exports = {
   plugins: [
     new CleanWebpackPlugin(),
     new HtmlWebpackPlugin({
-      template: "./public/index.html",
-      favicon: "./public/favicon.ico",
+      template: './public/index.html',
+      favicon: './public/favicon.ico',
+      filename: 'index.html',
+      chunks: ['main'],
     }),
+    new HtmlWebpackPlugin({
+      template: './public/index.html',
+      favicon: './public/favicon.ico',
+      filename: 'admin.html',
+      chunks: ['admin'],
+    })
   ],
 };


### PR DESCRIPTION
https://github.com/lee-jooyeon/react_basic/pull/6 의 수정편입니다.

- eslint 를 재반영했습니다.
- 여러 번들파일을 만드는 정답은 `output.filename 에 [name] 을 붙인다` 입니다.
  - 이때 [name] 은 특수한 기능을 하는데요. entry 의 object key 를 넣습니다. (디폴트는 main 입니다.)
  - 이렇게 수정하면 output.filename 은 여러 엔트리포인트를 만날때마다 이름을 바꾸기때문에, 충돌나지 않습니다.
    이전이었다면, main 엔트리포인트도 admin 엔트리포인트도 파일명이 bundle.js 로 만들어지기 때문에 충돌이 났었습니다
- 또한 번들파일을 로드하는 html 파일도 둘로 나누었습니다.
  - 만약 동일한 html 파일이 두 번들 파일을 로드해버린다면, 충돌이 발생해버립니다.
  - 왜냐면 둘다 동일한 element id (root) 를 찾아서 렌더하기 때문이죠.

질문이 있으시면 요기 코멘트 달아주시면 됩니다