### PR TITLE
feat: admin mock API 를 추가한다

### DIFF
--- a/src/admin/AdminPage.jsx
+++ b/src/admin/AdminPage.jsx
@@ -1,9 +1,57 @@
-import React from "react";
+import React, {useCallback, useRef, useEffect, useState} from 'react';
 
 export default function AdminPage() {
+  const domainRef = useRef(null);
+  const companyNameRef = useRef(null);
+  const [domainList, setDomainList] = useState([]);
+
+  const refreshDomains = useCallback(() => {
+    fetch('/admin/domains').then((response) => {
+      if (response.ok) {
+        response.json().then(setDomainList);
+      } else {
+        response.text().then(alert);
+      }
+    });
+  }, []);
+
+  const addDomain = () => {
+    const domain = domainRef.current?.value;
+    const companyName = companyNameRef.current?.value;
+
+    if (domain && companyName) {
+      fetch('/admin/domains', {
+        method: 'POST',
+        body: JSON.stringify({domain, companyName})
+      }).then(refreshDomains);
+    }
+  };
+  
+  useEffect(() => {
+    refreshDomains();
+  }, []);
+
   return (
     <div>
       <h1>Admin Page</h1>
+      {
+        domainList && (
+          <div>
+            {domainList.map(({domain, companyName}, index) => <div key={index}>{`도메인: ${domain} | 이메일: ${companyName}`}</div>)}
+          </div>
+        )
+      }
+      <div>
+        <div>
+          <label htmlFor={'domain-input'}>도메인</label>
+          <input ref={domainRef} id={'domain-input'} type={'text'} />
+        </div>
+        <div>
+          <label htmlFor={'company-input'}>회사명</label>
+          <input ref={companyNameRef} id={'company-input'} type={'text'} />
+        </div>
+      </div>
+      <button onClick={addDomain}>등록</button>
     </div>
   );
 }

--- a/src/admin/index.jsx
+++ b/src/admin/index.jsx
@@ -1,6 +1,11 @@
-import React from "react";
-import { createRoot } from "react-dom/client";
-import AdminPage from "./adminPage";
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import AdminPage from './adminPage';
 
-const root = createRoot(document.getElementById("root"));
+if (process.env.NODE_ENV === 'development') {
+  const {worker} = require('../mocks/browser');
+  worker.start();
+}
+
+const root = createRoot(document.getElementById('root'));
 root.render(<AdminPage />);

--- a/src/mocks/admin.js
+++ b/src/mocks/admin.js
@@ -1,0 +1,32 @@
+import {rest} from 'msw';
+
+const DOMAIN_API_STORAGE_KEY = 'MSW:DOMAIN';
+
+const getDomainsFromStorage = () => JSON.parse(localStorage.getItem(DOMAIN_API_STORAGE_KEY) || '[]');
+const setDomainsToStorage = (obj) => {
+  const db = JSON.parse(localStorage.getItem(DOMAIN_API_STORAGE_KEY) || '[]');
+  db.push(obj);
+  localStorage.setItem(DOMAIN_API_STORAGE_KEY, JSON.stringify(db));
+};
+
+/*
+ * domain API 는 어드민에서 사용될 API 를 예상하여 작성하였음.
+ * - GET /admin/domains : {domain: string, companyName: string} 을 내려준다.
+ * - POST /admin/domains : {domain: string, companyName: string} 을 보낼 수 있으면, HTTP Status 로 확인한다.
+ */
+export const domainApiHandlers = [
+  rest.get('/admin/domains', (_, res, ctx) => {
+    const dbResponse = getDomainsFromStorage();
+    return res(ctx.status(200), ctx.json(dbResponse));
+  }),
+  rest.post('/admin/domains', async (req, res, ctx) => {
+    const response = await req.json();
+
+    if (!(response.domain && response.companyName)) {
+      return res(ctx.status(400));
+    } else {
+      setDomainsToStorage(response);
+      return res(ctx.status(200));
+    }
+  }),
+];

--- a/src/mocks/browser.js
+++ b/src/mocks/browser.js
@@ -1,4 +1,5 @@
 import { setupWorker } from 'msw';
 import { handlers } from './handlers';
+import {domainApiHandlers} from './admin';
 // This configures a Service Worker with the given request handlers.
-export const worker = setupWorker(...handlers);
+export const worker = setupWorker(...handlers, ...domainApiHandlers);


### PR DESCRIPTION
- 실제로 사용할지 여부는 모르나, 어드민에서 호출테스트를 해볼 수 있는 mock API 를 추가했습니다.
- 테스트용으로 추가했기 때문에 리팩토링이 되어있지 않습니다.


## API 사용법

- GET /admin/domains 를 요청하면 {domain, companyName} 의 배열이 내려옵니다.
- POST /admin/domains 와 함께 requestBody 에 {domain, companyName} 을 전달하면 추가됩니다.
- 이 값은 웹페이지를 껏다켜도 유지됩니다 ([localStorage](https://developer.mozilla.org/ko/docs/Web/API/Window/localStorage)를 활용했습니다)

## 기타

- 코드의 재사용성, 추상화적인 측면에서 어떤 부분을 리팩토링하면 좋을까 한번 봐보실래요?
  - 키워드에 대해서 잘 이해가 안가는 부분도 말씀해주세요!
  - 코드를 보고 이해가 안가는 부분도 질문해주세요
- 코드 라인별 코멘트는, 아래의 순서로 하실 수 있습니다
  - 이 PR 의 상단탭 클릭
  - Files changed
  - 코멘트하고싶은 코드라인 에 마우스올리면 생기는 파란색 + 버튼클릭
  - 리뷰코멘트 추가 (single comment 는 바로 추가됩니다)
  - pending comment 들을 리뷰로 올리기 위해최상단의 Review changes 를 누르면 됩니다