### PR TITLE
feat: 로그아웃 API, 로그인체크 API 를 추가한다

### DIFF
--- a/packages/server/src/app.module.ts
+++ b/packages/server/src/app.module.ts
@@ -6,6 +6,8 @@ import { AuthModule } from './domains/auth/auth.module';
 import { HeartbeatController } from './heartbeat.controller';
 import * as path from 'path';
 
+const ROOT_PROJECT_DIR = path.join(__dirname, '../../..');
+
 @Module({
   controllers: [HeartbeatController],
   imports: [
@@ -14,7 +16,7 @@ import * as path from 'path';
       envFilePath: `.env.${process.env.NODE_ENV}`,
     }),
     ServeStaticModule.forRoot({
-      rootPath: path.join(__dirname, '../../../client', 'dist'),
+      rootPath: path.join(ROOT_PROJECT_DIR, 'packages/client', 'dist'),
     }),
     ShopListModule,
     AuthModule,

--- a/packages/server/src/domains/auth/auth.controller.ts
+++ b/packages/server/src/domains/auth/auth.controller.ts
@@ -6,9 +6,11 @@ import {
   Query,
   Redirect,
   Session,
+  UseGuards,
 } from '@nestjs/common';
 
 import { AuthService } from './auth.service';
+import { AuthGuard } from './auth.guard';
 
 @Controller('auth')
 export class AuthController {
@@ -34,10 +36,8 @@ export class AuthController {
   }
 
   @Get('user')
+  @UseGuards(AuthGuard)
   async getKakaoUserInfo(@Session() session: Record<string, any>) {
-    if (!session.tokens) {
-      throw new HttpException('Forbidden', HttpStatus.FORBIDDEN);
-    }
     return await this.authService.getUserInfo(session.tokens.access_token);
   }
 

--- a/packages/server/src/domains/auth/auth.controller.ts
+++ b/packages/server/src/domains/auth/auth.controller.ts
@@ -40,4 +40,9 @@ export class AuthController {
     }
     return await this.authService.getUserInfo(session.tokens.access_token);
   }
+
+  @Get('check')
+  loginCheck(@Session() session: Record<string, any>) {
+    return !!session.tokens;
+  }
 }

--- a/packages/server/src/domains/auth/auth.controller.ts
+++ b/packages/server/src/domains/auth/auth.controller.ts
@@ -38,11 +38,25 @@ export class AuthController {
   @Get('user')
   @UseGuards(AuthGuard)
   async getKakaoUserInfo(@Session() session: Record<string, any>) {
-    return await this.authService.getUserInfo(session.tokens.access_token);
+    const info = await this.authService.getUserInfo(
+      session.tokens.access_token,
+    );
+    session.info = info;
+    return info;
   }
 
   @Get('check')
   loginCheck(@Session() session: Record<string, any>) {
     return !!session.tokens;
+  }
+
+  @Get('logout')
+  async logout(@Session() session: Record<string, any>) {
+    if (session.tokens) {
+      const response = await this.authService.kakaoLogout(session.tokens);
+      delete session.tokens;
+      return 'ok';
+    }
+    return 'not ok'; // NOTE 200 은 맞으나 tokens 이 없어 로그아웃 동작이 수행된 적은 없다
   }
 }

--- a/packages/server/src/domains/auth/auth.guard.ts
+++ b/packages/server/src/domains/auth/auth.guard.ts
@@ -1,0 +1,13 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Observable } from 'rxjs';
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  canActivate(
+    context: ExecutionContext,
+  ): boolean | Promise<boolean> | Observable<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const { session } = request;
+    return !!session.tokens;
+  }
+}

--- a/packages/server/src/domains/auth/auth.service.ts
+++ b/packages/server/src/domains/auth/auth.service.ts
@@ -34,6 +34,18 @@ export class AuthService {
     return await response.json();
   }
 
+  async kakaoLogout(accessToken: any) {
+    console.log(accessToken);
+    const response = await fetch('https://kapi.kakao.com/v1/user/logout', {
+      method: 'post',
+      headers: {
+        Authorization: `Bearer ${accessToken.access_token}`,
+        'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
+      },
+    });
+    return response.json();
+  }
+
   async getUserInfo(accessToken: string) {
     const response = await fetch('https://kapi.kakao.com/v2/user/me', {
       headers: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10235,11 +10235,11 @@ __metadata:
 
 "typescript@patch:typescript@4.9.5#~builtin<compat/typescript>":
   version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=23ec76"
+  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=289587"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: ab417a2f398380c90a6cf5a5f74badd17866adf57f1165617d6a551f059c3ba0a3e4da0d147b3ac5681db9ac76a303c5876394b13b3de75fdd5b1eaa06181c9d
+  checksum: 1f8f3b6aaea19f0f67cba79057674ba580438a7db55057eb89cc06950483c5d632115c14077f6663ea76fd09fce3c190e6414bb98582ec80aa5a4eaf345d5b68
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- GET /auth/logout 가 추가되었습니다. 얘를 호출하고 200 이 떨어지면 session 에 할당되었던 토큰이 사라집니다
- GET /auth/check 가 추가되었습니다. 해당 세션이 카카오로그인이 되어있는 경우는 true, 그렇지 않으면 false 가 떨어집니다