### PR TITLE
feat: POST /shop-list 에서 이미지를 업로드할 수 있다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ coverage
 # production
 dist
 build
+resources
 
 # misc
 .DS_Store
@@ -41,3 +42,6 @@ logs
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# etc
+*.pem

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -36,6 +36,7 @@
     "@types/express": "^4.17.13",
     "@types/express-session": "^1.17.7",
     "@types/jest": "^29.5.3",
+    "@types/multer": "^1.4.7",
     "@types/node": "18.16.12",
     "@types/node-fetch": "^2.6.4",
     "@types/passport-local": "^1.0.35",

--- a/packages/server/src/app.module.ts
+++ b/packages/server/src/app.module.ts
@@ -29,6 +29,10 @@ const ROOT_PROJECT_DIR = path.join(__dirname, '../../..');
       inject: [ConfigService],
     }),
     ServeStaticModule.forRoot({
+      rootPath: path.join(ROOT_PROJECT_DIR, 'packages/server', 'resources'),
+      serveRoot: '/resources',
+    }),
+    ServeStaticModule.forRoot({
       rootPath: path.join(ROOT_PROJECT_DIR, 'packages/client', 'dist'),
     }),
     ShopModule,

--- a/packages/server/src/main.ts
+++ b/packages/server/src/main.ts
@@ -7,7 +7,7 @@ import { ValidationPipe } from '@nestjs/common';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.enableCors();
-  app.useGlobalPipes(new ValidationPipe());
+  app.useGlobalPipes(new ValidationPipe({ transform: true }));
   app.use(
     session({
       secret: 'keyboard',

--- a/packages/server/src/modules/shop/dto/create-shop.dto.ts
+++ b/packages/server/src/modules/shop/dto/create-shop.dto.ts
@@ -1,5 +1,12 @@
 import { FoodTypes, PriceRanges } from '../../../constants/shop';
-import { IsArray, IsEnum, IsNotEmpty, IsOptional } from 'class-validator';
+import {
+  IsArray,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+import { Transform } from 'class-transformer';
 
 export class CreateShopDto {
   @IsNotEmpty()
@@ -13,7 +20,8 @@ export class CreateShopDto {
   @IsNotEmpty()
   priceRange: keyof typeof PriceRanges;
 
-  @IsArray()
+  @IsString({ each: true })
+  @Transform(({ obj, key }) => obj[key].filter((val) => val))
   tags: string[];
 
   @IsArray()

--- a/packages/server/src/modules/shop/shop.module.ts
+++ b/packages/server/src/modules/shop/shop.module.ts
@@ -3,10 +3,14 @@ import { ShopService } from './shop.service';
 import { ShopController } from './shop.controller';
 import { MongooseModule } from '@nestjs/mongoose';
 import { Shop, ShopSchema } from './schemas/shop.schema';
+import { MulterModule } from '@nestjs/platform-express';
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: Shop.name, schema: ShopSchema }]),
+    MulterModule.register({
+      dest: './resources',
+    }),
   ],
   controllers: [ShopController],
   providers: [ShopService],

--- a/packages/server/tsconfig.build.json
+++ b/packages/server/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["test", "dist", "**/*spec.ts"]
+  "exclude": ["test", "dist", "resources", "**/*spec.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2539,6 +2539,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/multer@npm:^1.4.7":
+  version: 1.4.7
+  resolution: "@types/multer@npm:1.4.7"
+  dependencies:
+    "@types/express": "*"
+  checksum: 680cb0710aa25264d20cdcdaf34c212b636b55ea141310f06c25354ab1401193c7aa6839f9d22abf64a223fab1f2b8287f2512b0bef7e1628c4e9ffe54b4aeb2
+  languageName: node
+  linkType: hard
+
 "@types/node-fetch@npm:^2.6.4":
   version: 2.6.4
   resolution: "@types/node-fetch@npm:2.6.4"
@@ -9460,6 +9469,7 @@ __metadata:
     "@types/express": ^4.17.13
     "@types/express-session": ^1.17.7
     "@types/jest": ^29.5.3
+    "@types/multer": ^1.4.7
     "@types/node": 18.16.12
     "@types/node-fetch": ^2.6.4
     "@types/passport-local": ^1.0.35


### PR DESCRIPTION
- POST /shop-list 에서 이제 실제 이미지를 업로드할 수 있습니다
- 업로드 할 때는 form-data Content-Type 으로 요청합니다
- field 는 imageUrl 을 제외하고서는 전부 동일하며, imageUrl 대신 image 필드를 씁니다.
- image 필드는 복수개 전달받으며 File DOM Object 자체를 넘깁니다 (blob 주소 아니예요!)
- 이렇게 올리면 imageUrls 는 자동으로 만들어져서 내려옵니다.
  - 이때 주소는 /resources/... 입니다. 서버에서는 run-eat/resources/... 가 되겠죠? 이 주소는 이미지를 업로드한 경로로 매핑했습니다. 그러니까 프론트에선 라우팅경로로 쓰시면 안되요