### PR TITLE
feat: 이미지 업로드를 aws-s3 로 가도록 기능 구현

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -25,6 +25,7 @@
     "rxjs": "^7.2.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-s3": "^3.410.0",
     "@nestjs/cli": "^9.0.0",
     "@nestjs/config": "^3.0.0",
     "@nestjs/mongoose": "^10.0.1",
@@ -37,6 +38,7 @@
     "@types/express-session": "^1.17.7",
     "@types/jest": "^29.5.3",
     "@types/multer": "^1.4.7",
+    "@types/multer-s3": "^3",
     "@types/node": "18.16.12",
     "@types/node-fetch": "^2.6.4",
     "@types/passport-local": "^1.0.35",
@@ -54,6 +56,7 @@
     "express-session": "^1.17.3",
     "jest": "^29.6.1",
     "mongoose": "^7.4.3",
+    "multer-s3": "^3.0.1",
     "node-fetch": "2",
     "passport": "^0.6.0",
     "passport-local": "^1.0.0",

--- a/packages/server/src/constants/urls.ts
+++ b/packages/server/src/constants/urls.ts
@@ -1,0 +1,1 @@
+export const RESOURCE_DOMAIN_URL = 'https://resources.run-eat.com/';

--- a/packages/server/src/modules/shop/shop.controller.ts
+++ b/packages/server/src/modules/shop/shop.controller.ts
@@ -1,4 +1,3 @@
-import * as path from 'path';
 import {
   Body,
   Controller,
@@ -18,9 +17,7 @@ import { CreateShopDto } from './dto/create-shop.dto';
 import { AuthGuard } from '../../auth/auth.guard';
 import { UpdateShopDto } from './dto/update-shop.dto';
 import { FilesInterceptor } from '@nestjs/platform-express';
-
-const toPosixPath = (filePath: string) =>
-  `${path.posix.sep}${filePath.split(path.sep).join(path.posix.sep)}`;
+import { RESOURCE_DOMAIN_URL } from '../../constants/urls';
 
 @Controller('shop-list')
 export class ShopController {
@@ -36,11 +33,11 @@ export class ShopController {
         validators: [new FileTypeValidator({ fileType: /image\/*/ })],
       }),
     )
-    images: Array<Express.Multer.File>,
+    images?: Array<Express.MulterS3.File>,
   ) {
     // NOTE form-data 에서 발생한 null prototype object 를 Object prototype based object 로 만들기 위함
     const createShopListDto = Object.assign({}, _createShopListDto, {
-      imageUrls: images.map(({ path: imagePath }) => toPosixPath(imagePath)),
+      imageUrls: images?.map(({ key }) => `${RESOURCE_DOMAIN_URL}${key}`) || [],
     });
     return this.shopService.create(createShopListDto);
   }

--- a/packages/server/src/modules/shop/shop.module.ts
+++ b/packages/server/src/modules/shop/shop.module.ts
@@ -4,12 +4,36 @@ import { ShopController } from './shop.controller';
 import { MongooseModule } from '@nestjs/mongoose';
 import { Shop, ShopSchema } from './schemas/shop.schema';
 import { MulterModule } from '@nestjs/platform-express';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import * as multerS3 from 'multer-s3';
+import { MulterOptions } from '@nestjs/platform-express/multer/interfaces/multer-options.interface';
+import { S3Client } from '@aws-sdk/client-s3';
+
+const multerOptionsFactory = (configService: ConfigService): MulterOptions => ({
+  storage: multerS3({
+    s3: new S3Client({
+      region: configService.get('AWS_S3_REGION'),
+      credentials: {
+        accessKeyId: configService.get('AWS_S3_ACCESS_KEY_ID'),
+        secretAccessKey: configService.get('AWS_S3_SECRET_ACCESS_KEY'),
+      },
+    }),
+    bucket: configService.get('AWS_S3_BUCKET'),
+    contentType: multerS3.AUTO_CONTENT_TYPE,
+    cacheControl: 'max-age=31536000',
+    key: function (req, file, cb) {
+      cb(null, Date.now().toString());
+    },
+  }),
+});
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: Shop.name, schema: ShopSchema }]),
-    MulterModule.register({
-      dest: './resources',
+    MulterModule.registerAsync({
+      imports: [ConfigModule],
+      useFactory: multerOptionsFactory,
+      inject: [ConfigService],
     }),
   ],
   controllers: [ShopController],

--- a/yarn.lock
+++ b/yarn.lock
@@ -76,6 +76,652 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-crypto/crc32@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/crc32@npm:3.0.0"
+  dependencies:
+    "@aws-crypto/util": ^3.0.0
+    "@aws-sdk/types": ^3.222.0
+    tslib: ^1.11.1
+  checksum: 9fdb3e837fc54119b017ea34fd0a6d71d2c88075d99e1e818a5158e0ad30ced67ddbcc423a11ceeef6cc465ab5ffd91830acab516470b48237ca7abd51be9642
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/crc32c@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/crc32c@npm:3.0.0"
+  dependencies:
+    "@aws-crypto/util": ^3.0.0
+    "@aws-sdk/types": ^3.222.0
+    tslib: ^1.11.1
+  checksum: 0a116b5d1c5b09a3dde65aab04a07b32f543e87b68f2d175081e3f4a1a17502343f223d691dd883ace1ddce65cd40093673e7c7415dcd99062202ba87ffb4038
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/ie11-detection@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/ie11-detection@npm:3.0.0"
+  dependencies:
+    tslib: ^1.11.1
+  checksum: 299b2ddd46eddac1f2d54d91386ceb37af81aef8a800669281c73d634ed17fd855dcfb8b3157f2879344b93a2666a6d602550eb84b71e4d7868100ad6da8f803
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha1-browser@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/sha1-browser@npm:3.0.0"
+  dependencies:
+    "@aws-crypto/ie11-detection": ^3.0.0
+    "@aws-crypto/supports-web-crypto": ^3.0.0
+    "@aws-crypto/util": ^3.0.0
+    "@aws-sdk/types": ^3.222.0
+    "@aws-sdk/util-locate-window": ^3.0.0
+    "@aws-sdk/util-utf8-browser": ^3.0.0
+    tslib: ^1.11.1
+  checksum: 78c379e105a0c4e7b2ed745dffd8f55054d7dde8b350b61de682bbc3cd081a50e2f87861954fa9cd53c7ea711ebca1ca0137b14cb36483efc971f60f573cf129
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha256-browser@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/sha256-browser@npm:3.0.0"
+  dependencies:
+    "@aws-crypto/ie11-detection": ^3.0.0
+    "@aws-crypto/sha256-js": ^3.0.0
+    "@aws-crypto/supports-web-crypto": ^3.0.0
+    "@aws-crypto/util": ^3.0.0
+    "@aws-sdk/types": ^3.222.0
+    "@aws-sdk/util-locate-window": ^3.0.0
+    "@aws-sdk/util-utf8-browser": ^3.0.0
+    tslib: ^1.11.1
+  checksum: ca89456bf508db2e08060a7f656460db97ac9a15b11e39d6fa7665e2b156508a1758695bff8e82d0a00178d6ac5c36f35eb4bcfac2e48621265224ca14a19bd2
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha256-js@npm:3.0.0, @aws-crypto/sha256-js@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/sha256-js@npm:3.0.0"
+  dependencies:
+    "@aws-crypto/util": ^3.0.0
+    "@aws-sdk/types": ^3.222.0
+    tslib: ^1.11.1
+  checksum: 644ded32ea310237811afae873d3c7320739cb6f6cc39dced9c94801379e68e5ee2cca0c34f0384793fa9e750a7e0a5e2468f95754bd08e6fd72ab833c8fe23c
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/supports-web-crypto@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/supports-web-crypto@npm:3.0.0"
+  dependencies:
+    tslib: ^1.11.1
+  checksum: 35479a1558db9e9a521df6877a99f95670e972c602f2a0349303477e5d638a5baf569fb037c853710e382086e6fd77e8ed58d3fb9b49f6e1186a9d26ce7be006
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/util@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/util@npm:3.0.0"
+  dependencies:
+    "@aws-sdk/types": ^3.222.0
+    "@aws-sdk/util-utf8-browser": ^3.0.0
+    tslib: ^1.11.1
+  checksum: d29d5545048721aae3d60b236708535059733019a105f8a64b4e4a8eab7cf8dde1546dc56bff7de20d36140a4d1f0f4693e639c5732a7059273a7b1e56354776
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-s3@npm:^3.0.0, @aws-sdk/client-s3@npm:^3.410.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/client-s3@npm:3.410.0"
+  dependencies:
+    "@aws-crypto/sha1-browser": 3.0.0
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/client-sts": 3.410.0
+    "@aws-sdk/credential-provider-node": 3.410.0
+    "@aws-sdk/middleware-bucket-endpoint": 3.410.0
+    "@aws-sdk/middleware-expect-continue": 3.410.0
+    "@aws-sdk/middleware-flexible-checksums": 3.410.0
+    "@aws-sdk/middleware-host-header": 3.410.0
+    "@aws-sdk/middleware-location-constraint": 3.410.0
+    "@aws-sdk/middleware-logger": 3.410.0
+    "@aws-sdk/middleware-recursion-detection": 3.410.0
+    "@aws-sdk/middleware-sdk-s3": 3.410.0
+    "@aws-sdk/middleware-signing": 3.410.0
+    "@aws-sdk/middleware-ssec": 3.410.0
+    "@aws-sdk/middleware-user-agent": 3.410.0
+    "@aws-sdk/signature-v4-multi-region": 3.410.0
+    "@aws-sdk/types": 3.410.0
+    "@aws-sdk/util-endpoints": 3.410.0
+    "@aws-sdk/util-user-agent-browser": 3.410.0
+    "@aws-sdk/util-user-agent-node": 3.410.0
+    "@aws-sdk/xml-builder": 3.310.0
+    "@smithy/config-resolver": ^2.0.7
+    "@smithy/eventstream-serde-browser": ^2.0.6
+    "@smithy/eventstream-serde-config-resolver": ^2.0.6
+    "@smithy/eventstream-serde-node": ^2.0.6
+    "@smithy/fetch-http-handler": ^2.1.2
+    "@smithy/hash-blob-browser": ^2.0.6
+    "@smithy/hash-node": ^2.0.6
+    "@smithy/hash-stream-node": ^2.0.6
+    "@smithy/invalid-dependency": ^2.0.6
+    "@smithy/md5-js": ^2.0.6
+    "@smithy/middleware-content-length": ^2.0.8
+    "@smithy/middleware-endpoint": ^2.0.6
+    "@smithy/middleware-retry": ^2.0.9
+    "@smithy/middleware-serde": ^2.0.6
+    "@smithy/middleware-stack": ^2.0.0
+    "@smithy/node-config-provider": ^2.0.9
+    "@smithy/node-http-handler": ^2.1.2
+    "@smithy/protocol-http": ^3.0.2
+    "@smithy/smithy-client": ^2.1.3
+    "@smithy/types": ^2.3.0
+    "@smithy/url-parser": ^2.0.6
+    "@smithy/util-base64": ^2.0.0
+    "@smithy/util-body-length-browser": ^2.0.0
+    "@smithy/util-body-length-node": ^2.1.0
+    "@smithy/util-defaults-mode-browser": ^2.0.7
+    "@smithy/util-defaults-mode-node": ^2.0.9
+    "@smithy/util-retry": ^2.0.0
+    "@smithy/util-stream": ^2.0.9
+    "@smithy/util-utf8": ^2.0.0
+    "@smithy/util-waiter": ^2.0.6
+    fast-xml-parser: 4.2.5
+    tslib: ^2.5.0
+  checksum: 3f5acbf6eb5e0795265e0f436334547cbbb78ee3c01b184e00466ebe821972143d5545e70d9179aad15fbfe6be015cdccb94d74c67f8a91706f9c9576d5b62f9
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-sso@npm:3.410.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/client-sso@npm:3.410.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/middleware-host-header": 3.410.0
+    "@aws-sdk/middleware-logger": 3.410.0
+    "@aws-sdk/middleware-recursion-detection": 3.410.0
+    "@aws-sdk/middleware-user-agent": 3.410.0
+    "@aws-sdk/types": 3.410.0
+    "@aws-sdk/util-endpoints": 3.410.0
+    "@aws-sdk/util-user-agent-browser": 3.410.0
+    "@aws-sdk/util-user-agent-node": 3.410.0
+    "@smithy/config-resolver": ^2.0.7
+    "@smithy/fetch-http-handler": ^2.1.2
+    "@smithy/hash-node": ^2.0.6
+    "@smithy/invalid-dependency": ^2.0.6
+    "@smithy/middleware-content-length": ^2.0.8
+    "@smithy/middleware-endpoint": ^2.0.6
+    "@smithy/middleware-retry": ^2.0.9
+    "@smithy/middleware-serde": ^2.0.6
+    "@smithy/middleware-stack": ^2.0.0
+    "@smithy/node-config-provider": ^2.0.9
+    "@smithy/node-http-handler": ^2.1.2
+    "@smithy/protocol-http": ^3.0.2
+    "@smithy/smithy-client": ^2.1.3
+    "@smithy/types": ^2.3.0
+    "@smithy/url-parser": ^2.0.6
+    "@smithy/util-base64": ^2.0.0
+    "@smithy/util-body-length-browser": ^2.0.0
+    "@smithy/util-body-length-node": ^2.1.0
+    "@smithy/util-defaults-mode-browser": ^2.0.7
+    "@smithy/util-defaults-mode-node": ^2.0.9
+    "@smithy/util-retry": ^2.0.0
+    "@smithy/util-utf8": ^2.0.0
+    tslib: ^2.5.0
+  checksum: 572a3b080b47078f51b228fb4651f69c7f98c71331565cf5a97a3bbfe503de3b2468e05e7dd504e56de6d16373e738368cdea6623e408c66dcb528892a9bd728
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-sts@npm:3.410.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/client-sts@npm:3.410.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/credential-provider-node": 3.410.0
+    "@aws-sdk/middleware-host-header": 3.410.0
+    "@aws-sdk/middleware-logger": 3.410.0
+    "@aws-sdk/middleware-recursion-detection": 3.410.0
+    "@aws-sdk/middleware-sdk-sts": 3.410.0
+    "@aws-sdk/middleware-signing": 3.410.0
+    "@aws-sdk/middleware-user-agent": 3.410.0
+    "@aws-sdk/types": 3.410.0
+    "@aws-sdk/util-endpoints": 3.410.0
+    "@aws-sdk/util-user-agent-browser": 3.410.0
+    "@aws-sdk/util-user-agent-node": 3.410.0
+    "@smithy/config-resolver": ^2.0.7
+    "@smithy/fetch-http-handler": ^2.1.2
+    "@smithy/hash-node": ^2.0.6
+    "@smithy/invalid-dependency": ^2.0.6
+    "@smithy/middleware-content-length": ^2.0.8
+    "@smithy/middleware-endpoint": ^2.0.6
+    "@smithy/middleware-retry": ^2.0.9
+    "@smithy/middleware-serde": ^2.0.6
+    "@smithy/middleware-stack": ^2.0.0
+    "@smithy/node-config-provider": ^2.0.9
+    "@smithy/node-http-handler": ^2.1.2
+    "@smithy/protocol-http": ^3.0.2
+    "@smithy/smithy-client": ^2.1.3
+    "@smithy/types": ^2.3.0
+    "@smithy/url-parser": ^2.0.6
+    "@smithy/util-base64": ^2.0.0
+    "@smithy/util-body-length-browser": ^2.0.0
+    "@smithy/util-body-length-node": ^2.1.0
+    "@smithy/util-defaults-mode-browser": ^2.0.7
+    "@smithy/util-defaults-mode-node": ^2.0.9
+    "@smithy/util-retry": ^2.0.0
+    "@smithy/util-utf8": ^2.0.0
+    fast-xml-parser: 4.2.5
+    tslib: ^2.5.0
+  checksum: 76d786a0be8575ebac48640e40191a99514799e63f69e5596cff8c4424acca483dc42dca0a16cc540b0df6c527d5c1d4452f990c92ae4f094392dfab1d94c4c1
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-env@npm:3.410.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/credential-provider-env@npm:3.410.0"
+  dependencies:
+    "@aws-sdk/types": 3.410.0
+    "@smithy/property-provider": ^2.0.0
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: 3fb23edaa7b30b4287c5edf4cb3bad66d7119d31d9f4022304719c576ed0b26ce108b9f814c352514a0958b1179f376c8ce1aba48a9af97a45e6ed5816848b98
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-ini@npm:3.410.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.410.0"
+  dependencies:
+    "@aws-sdk/credential-provider-env": 3.410.0
+    "@aws-sdk/credential-provider-process": 3.410.0
+    "@aws-sdk/credential-provider-sso": 3.410.0
+    "@aws-sdk/credential-provider-web-identity": 3.410.0
+    "@aws-sdk/types": 3.410.0
+    "@smithy/credential-provider-imds": ^2.0.0
+    "@smithy/property-provider": ^2.0.0
+    "@smithy/shared-ini-file-loader": ^2.0.6
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: bad145bae4b7ec6e5d7ac6ceef0e7de62e3dfd54a30f0ca1b8800e4919302492b4a0dfe467791bc516ffbdda18bfa580c69d7f4cbfb6c16ce5caaa0901296ee7
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-node@npm:3.410.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/credential-provider-node@npm:3.410.0"
+  dependencies:
+    "@aws-sdk/credential-provider-env": 3.410.0
+    "@aws-sdk/credential-provider-ini": 3.410.0
+    "@aws-sdk/credential-provider-process": 3.410.0
+    "@aws-sdk/credential-provider-sso": 3.410.0
+    "@aws-sdk/credential-provider-web-identity": 3.410.0
+    "@aws-sdk/types": 3.410.0
+    "@smithy/credential-provider-imds": ^2.0.0
+    "@smithy/property-provider": ^2.0.0
+    "@smithy/shared-ini-file-loader": ^2.0.6
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: 6b17eef1c4cd8c35ca9c9ba7c20ea78e05faef1e7c12edf2a462dc033f7b72896c66f3992b4ab7adb850ca4f7cc9751e6ea73a1fe95c5b0d2af01dcc67d03aa3
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-process@npm:3.410.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/credential-provider-process@npm:3.410.0"
+  dependencies:
+    "@aws-sdk/types": 3.410.0
+    "@smithy/property-provider": ^2.0.0
+    "@smithy/shared-ini-file-loader": ^2.0.6
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: aa1fe6d3fa1a013aa6ab53f67956afa03659c590e340b0c4ab6547bc5c61f02ba8f806e6e8895944cf810ed64bde4558adc5842dae8ac52820163ae7fe8c9cb1
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-sso@npm:3.410.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.410.0"
+  dependencies:
+    "@aws-sdk/client-sso": 3.410.0
+    "@aws-sdk/token-providers": 3.410.0
+    "@aws-sdk/types": 3.410.0
+    "@smithy/property-provider": ^2.0.0
+    "@smithy/shared-ini-file-loader": ^2.0.6
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: 897d583dd084cd58a3418bc14a05786686fb4d0c178079d5abfb8eff79ebcfbd82ebef27acfedd8b8b41db283c2d01817b8c7f00209c5472b621748a3295764b
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-web-identity@npm:3.410.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.410.0"
+  dependencies:
+    "@aws-sdk/types": 3.410.0
+    "@smithy/property-provider": ^2.0.0
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: 24f03dfcec7bcaf97bf9a00be1e1123e0ee79def60fbbb3c1b0ccad9d56e8d3479e00b530a97e6bf7d51022784ef3bde7456ae1fd1973d9ccd10d8d93a1c3fa3
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/lib-storage@npm:^3.46.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/lib-storage@npm:3.410.0"
+  dependencies:
+    "@smithy/abort-controller": ^2.0.1
+    "@smithy/middleware-endpoint": ^2.0.6
+    "@smithy/smithy-client": ^2.1.3
+    buffer: 5.6.0
+    events: 3.3.0
+    stream-browserify: 3.0.0
+    tslib: ^2.5.0
+  peerDependencies:
+    "@aws-sdk/client-s3": ^3.0.0
+  checksum: 3c0c0be48c87844054c1884ed65d15a2a7bf06d3e911e7cfb42a8f00b67ef9bbff5ac2a6f3215e07c07b02b13879c232b6d9e20140d52510df3dc6354236e25a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-bucket-endpoint@npm:3.410.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.410.0"
+  dependencies:
+    "@aws-sdk/types": 3.410.0
+    "@aws-sdk/util-arn-parser": 3.310.0
+    "@smithy/node-config-provider": ^2.0.9
+    "@smithy/protocol-http": ^3.0.2
+    "@smithy/types": ^2.3.0
+    "@smithy/util-config-provider": ^2.0.0
+    tslib: ^2.5.0
+  checksum: d8fd08130fbc5087a253d7f94a97f6636e582cbb5c1cf6336f47b878ad9efa972850756b77da7fc1927152aa1c43f43358e468e8738591ee68a23ee1c6a781a8
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-expect-continue@npm:3.410.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/middleware-expect-continue@npm:3.410.0"
+  dependencies:
+    "@aws-sdk/types": 3.410.0
+    "@smithy/protocol-http": ^3.0.2
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: e34a87ad4c107e77cbd4de354313fb55e52e8c30a14dee8b52040b10835d696ef24e8fd49144dbf3c8499050b3e7ff8e76a9e78ccab3c3a7cc8e97b0711465d7
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-flexible-checksums@npm:3.410.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.410.0"
+  dependencies:
+    "@aws-crypto/crc32": 3.0.0
+    "@aws-crypto/crc32c": 3.0.0
+    "@aws-sdk/types": 3.410.0
+    "@smithy/is-array-buffer": ^2.0.0
+    "@smithy/protocol-http": ^3.0.2
+    "@smithy/types": ^2.3.0
+    "@smithy/util-utf8": ^2.0.0
+    tslib: ^2.5.0
+  checksum: 3d8670d13dc54eea0797681e6c45d5779da1b14a0d6dbc8006e7126f885a9dbb3cc7572650ca9ada2a58aeab9135c927c92e867725a2305a8a602eac112a8fc4
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-host-header@npm:3.410.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/middleware-host-header@npm:3.410.0"
+  dependencies:
+    "@aws-sdk/types": 3.410.0
+    "@smithy/protocol-http": ^3.0.2
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: 34f035c3e6dc5951f9ec4b86cd6fbf16fcd81e716c080c482137867799c53fb851656b17d059f306c4f84df34b6d7f0803d20c82252a9e128912e4bcced6a9ad
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-location-constraint@npm:3.410.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/middleware-location-constraint@npm:3.410.0"
+  dependencies:
+    "@aws-sdk/types": 3.410.0
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: a0a8860a447ef66a2212adc663845899fdd8946e9100ea4e668aa7888ab1a61d7018c06653032890abe88314b4779f104e42e50de33f673eb68e377d1dcc7434
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-logger@npm:3.410.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/middleware-logger@npm:3.410.0"
+  dependencies:
+    "@aws-sdk/types": 3.410.0
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: dca41a62f760b6c17431b0bee153982e69db57269fbbe983658c3fb4b0fe2bc163a230c59927493e95ea88a40e70ea7a23acf0a2af67116eec96dd940d393a3e
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-recursion-detection@npm:3.410.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.410.0"
+  dependencies:
+    "@aws-sdk/types": 3.410.0
+    "@smithy/protocol-http": ^3.0.2
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: ee39ca266f1b9d008bc94252065b33b384d342f2d7a816d542a1ea1dea5ef9e543a28307aa232b29b81ace072d3b25d671d3653ed1721cd575cc42a92ff0eca4
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-sdk-s3@npm:3.410.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.410.0"
+  dependencies:
+    "@aws-sdk/types": 3.410.0
+    "@aws-sdk/util-arn-parser": 3.310.0
+    "@smithy/protocol-http": ^3.0.2
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: 75aa8a106679ecc025d1d68843cc959c74dccbb0e8b41296f5561fafe06caa95a70ff0104a0be006f5f5933367a717de44f66c34aac652375549c6c087f96336
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-sdk-sts@npm:3.410.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/middleware-sdk-sts@npm:3.410.0"
+  dependencies:
+    "@aws-sdk/middleware-signing": 3.410.0
+    "@aws-sdk/types": 3.410.0
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: 4f07f5905265d41aa7c1d78bf06dcbf56a897b032f05d9adba98c8f05440dfa048f4a15f9e13b0acdf6bb164d6732e96a37dba7961160a909d6f7b5a42e11096
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-signing@npm:3.410.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/middleware-signing@npm:3.410.0"
+  dependencies:
+    "@aws-sdk/types": 3.410.0
+    "@smithy/property-provider": ^2.0.0
+    "@smithy/protocol-http": ^3.0.2
+    "@smithy/signature-v4": ^2.0.0
+    "@smithy/types": ^2.3.0
+    "@smithy/util-middleware": ^2.0.0
+    tslib: ^2.5.0
+  checksum: 6c5892975c052b0c50c42cfcf8dcc9286cdaef208cc82354d3c67aa5b56684d706a7afbe567d98c693cc099367ad1f98d5063075a6cb81e7f1bd8da88aa61171
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-ssec@npm:3.410.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/middleware-ssec@npm:3.410.0"
+  dependencies:
+    "@aws-sdk/types": 3.410.0
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: 4e7259dd8dd115f8440b798fe24fd41ffe44f7f887ea167550d402353ae2a163f6377a3c99c61d96d5f086c9dd44c59b9f50fc8b81d2701a95e8151893012b5a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-user-agent@npm:3.410.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.410.0"
+  dependencies:
+    "@aws-sdk/types": 3.410.0
+    "@aws-sdk/util-endpoints": 3.410.0
+    "@smithy/protocol-http": ^3.0.2
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: eae1e537bab9a93bbe3207d930a163edeef40f6d26c5a2d65b1fb20ab3f80f92582a5c5fc7de4fc631c76b4bdddfa2836ca68a0121dc0886bd4071fcaf69608b
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/signature-v4-multi-region@npm:3.410.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.410.0"
+  dependencies:
+    "@aws-sdk/types": 3.410.0
+    "@smithy/protocol-http": ^3.0.2
+    "@smithy/signature-v4": ^2.0.0
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  peerDependencies:
+    "@aws-sdk/signature-v4-crt": ^3.118.0
+  peerDependenciesMeta:
+    "@aws-sdk/signature-v4-crt":
+      optional: true
+  checksum: 54ccba40b37efd204ab625ca7cf371d86ddca5a6d9130a553d3c434a0cf0388602c19c587ba3d0e343a9868e21ed8e34e214dcb6e1291b9ca470c7597341920f
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/token-providers@npm:3.410.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/token-providers@npm:3.410.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/middleware-host-header": 3.410.0
+    "@aws-sdk/middleware-logger": 3.410.0
+    "@aws-sdk/middleware-recursion-detection": 3.410.0
+    "@aws-sdk/middleware-user-agent": 3.410.0
+    "@aws-sdk/types": 3.410.0
+    "@aws-sdk/util-endpoints": 3.410.0
+    "@aws-sdk/util-user-agent-browser": 3.410.0
+    "@aws-sdk/util-user-agent-node": 3.410.0
+    "@smithy/config-resolver": ^2.0.7
+    "@smithy/fetch-http-handler": ^2.1.2
+    "@smithy/hash-node": ^2.0.6
+    "@smithy/invalid-dependency": ^2.0.6
+    "@smithy/middleware-content-length": ^2.0.8
+    "@smithy/middleware-endpoint": ^2.0.6
+    "@smithy/middleware-retry": ^2.0.9
+    "@smithy/middleware-serde": ^2.0.6
+    "@smithy/middleware-stack": ^2.0.0
+    "@smithy/node-config-provider": ^2.0.9
+    "@smithy/node-http-handler": ^2.1.2
+    "@smithy/property-provider": ^2.0.0
+    "@smithy/protocol-http": ^3.0.2
+    "@smithy/shared-ini-file-loader": ^2.0.6
+    "@smithy/smithy-client": ^2.1.3
+    "@smithy/types": ^2.3.0
+    "@smithy/url-parser": ^2.0.6
+    "@smithy/util-base64": ^2.0.0
+    "@smithy/util-body-length-browser": ^2.0.0
+    "@smithy/util-body-length-node": ^2.1.0
+    "@smithy/util-defaults-mode-browser": ^2.0.7
+    "@smithy/util-defaults-mode-node": ^2.0.9
+    "@smithy/util-retry": ^2.0.0
+    "@smithy/util-utf8": ^2.0.0
+    tslib: ^2.5.0
+  checksum: 8b12efcafb96239dce72a18ad44937d0737b5ce557f1c9699113a38b455d9864c972f0d58204554d4a063ffa6d744b26cc9f09a2f92201660631cfe0b1cdd1c1
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/types@npm:3.410.0, @aws-sdk/types@npm:^3.222.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/types@npm:3.410.0"
+  dependencies:
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: 9de51a6b2e1c0012c9b2348eb4f334bcfedc4abd127cd1bc6d16ee5a65bc7f6f55d1742b0d3e7e97918897ea554d5508b4a4339fbedf34d06a33223d8f106bf6
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-arn-parser@npm:3.310.0":
+  version: 3.310.0
+  resolution: "@aws-sdk/util-arn-parser@npm:3.310.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: faac1e10f8bb6c2fe5fee82bcb7ce56c2b37ae9ffdb2b78b0746a7a06005eaa5ea747a0a10eaf490c1c4907ecc327e1c94a600e26a069e023e54b8d63c031e96
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-endpoints@npm:3.410.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/util-endpoints@npm:3.410.0"
+  dependencies:
+    "@aws-sdk/types": 3.410.0
+    tslib: ^2.5.0
+  checksum: 430f2959b82c1f1a5e7b5be97158699124293bd4e9d036e90ec3ac6af3fe8fb2e95a4e3b205c8244b81ef8a6073b134b714bb20d51c017bcbc5cc25a0d52a38a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-locate-window@npm:^3.0.0":
+  version: 3.310.0
+  resolution: "@aws-sdk/util-locate-window@npm:3.310.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: d552ce5f0f836ecb13d7920ae650552c56706f26a5e8abf894ba471e18775a3791869bda95269153735bac9d211efc3ba78ea01c34428c3fed4318ac693a08bc
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-user-agent-browser@npm:3.410.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.410.0"
+  dependencies:
+    "@aws-sdk/types": 3.410.0
+    "@smithy/types": ^2.3.0
+    bowser: ^2.11.0
+    tslib: ^2.5.0
+  checksum: 8e0d7a9f13d40d2a78ba1e45fa98c5491adaa7900c251399370af3e9e95c750deb25b39b431490ed5ec904f2d659ec8203f9affa21065a3112e491f32582d917
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-user-agent-node@npm:3.410.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.410.0"
+  dependencies:
+    "@aws-sdk/types": 3.410.0
+    "@smithy/node-config-provider": ^2.0.9
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  peerDependencies:
+    aws-crt: ">=1.0.0"
+  peerDependenciesMeta:
+    aws-crt:
+      optional: true
+  checksum: 371d22535abc7620453c9fd2abee535e00b6ab10744929244f71e5063aad829bf5b752480b728038cdcfd7f58e6c3da8de83870826c2c153012be7af880e5be5
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-utf8-browser@npm:^3.0.0":
+  version: 3.259.0
+  resolution: "@aws-sdk/util-utf8-browser@npm:3.259.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: b6a1e580da1c9b62c749814182a7649a748ca4253edb4063aa521df97d25b76eae3359eb1680b86f71aac668e05cc05c514379bca39ebf4ba998ae4348412da8
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/xml-builder@npm:3.310.0":
+  version: 3.310.0
+  resolution: "@aws-sdk/xml-builder@npm:3.310.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: fc17fd8f68470702d947948ada46097bdddecafdc68fa57bf584320e92748e8ef0372a51999d3ab7902ba4f62c2dbfbdec2dba1180fca19bb5127bad1ef0e48b
+  languageName: node
+  linkType: hard
+
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.16.7, @babel/code-frame@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/code-frame@npm:7.22.5"
@@ -2232,6 +2878,531 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/abort-controller@npm:^2.0.1, @smithy/abort-controller@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@smithy/abort-controller@npm:2.0.6"
+  dependencies:
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: f5d148b8bbd5aa93708651dee68f22b1e5adcfc78bc6dc12e325db4c374ea29965bc711448bf7a780693e9ba6b0682821a7e0a1e1227f8f71b50a3fc3ed4e9b1
+  languageName: node
+  linkType: hard
+
+"@smithy/chunked-blob-reader-native@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@smithy/chunked-blob-reader-native@npm:2.0.0"
+  dependencies:
+    "@smithy/util-base64": ^2.0.0
+    tslib: ^2.5.0
+  checksum: 5f656dbc4913ab8312b6e687938f534a2ed28e749335560c21a6975f691630ede80afc4a81007078692da4eaa91839ae0a6e65dc39f3faf4423538f5d9bef37b
+  languageName: node
+  linkType: hard
+
+"@smithy/chunked-blob-reader@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@smithy/chunked-blob-reader@npm:2.0.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: a47e5298f0b28e25eaa5825ea9737718f0e2b7cf0f03a49cca186eb5544dd20ac91a2d92069f9805e40e5f3ab34d32f8091853518672fdbca009411179dbeb2a
+  languageName: node
+  linkType: hard
+
+"@smithy/config-resolver@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "@smithy/config-resolver@npm:2.0.7"
+  dependencies:
+    "@smithy/node-config-provider": ^2.0.9
+    "@smithy/types": ^2.3.0
+    "@smithy/util-config-provider": ^2.0.0
+    "@smithy/util-middleware": ^2.0.0
+    tslib: ^2.5.0
+  checksum: ecfb858e9221534ea27ef4f554b1dccc3377a878592ded79b1efa61d49d44ab738ec841d957adf8a9cb2b3d0c4bb716be094c9352960fc5cd4ef1b6e35796ecc
+  languageName: node
+  linkType: hard
+
+"@smithy/credential-provider-imds@npm:^2.0.0, @smithy/credential-provider-imds@npm:^2.0.9":
+  version: 2.0.9
+  resolution: "@smithy/credential-provider-imds@npm:2.0.9"
+  dependencies:
+    "@smithy/node-config-provider": ^2.0.9
+    "@smithy/property-provider": ^2.0.7
+    "@smithy/types": ^2.3.0
+    "@smithy/url-parser": ^2.0.6
+    tslib: ^2.5.0
+  checksum: a286b8ff6c9b4f4010ed9444f5d8644a39071d6d93c7adbd424d8d5e73c4f2a39957ac65a7c86fecfa4522c1e3064699698d37d9ee96d2ac261a13e619c5d455
+  languageName: node
+  linkType: hard
+
+"@smithy/eventstream-codec@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@smithy/eventstream-codec@npm:2.0.6"
+  dependencies:
+    "@aws-crypto/crc32": 3.0.0
+    "@smithy/types": ^2.3.0
+    "@smithy/util-hex-encoding": ^2.0.0
+    tslib: ^2.5.0
+  checksum: f45701701873637760a4ad4fd4a90c62bb4cdd242745a775d0d3250f4e323dd813c52ec6d6974d14fd60325c7ed6251800479edfad8a1de00d4f8c8361d4ca7a
+  languageName: node
+  linkType: hard
+
+"@smithy/eventstream-serde-browser@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@smithy/eventstream-serde-browser@npm:2.0.6"
+  dependencies:
+    "@smithy/eventstream-serde-universal": ^2.0.6
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: 5438c566ea6979677f5e8ff6bc8c0d81df5571bfe5857b404233c486bad0b14dadf90c0ead01fc61f9441e6397bf0a154fa3dd213fb3f649af15b3f3cc99750a
+  languageName: node
+  linkType: hard
+
+"@smithy/eventstream-serde-config-resolver@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@smithy/eventstream-serde-config-resolver@npm:2.0.6"
+  dependencies:
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: d078a19550628f4c93c1bf2c813fb0d11f818796407df0c23bf78bae9b31ce629c937e224b34d0a0456cb3d10b53f109b1c3fa1ecdbeb5c544a9452d92da1a49
+  languageName: node
+  linkType: hard
+
+"@smithy/eventstream-serde-node@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@smithy/eventstream-serde-node@npm:2.0.6"
+  dependencies:
+    "@smithy/eventstream-serde-universal": ^2.0.6
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: 88076d347ad1b69fa1b999da7a90aca96d78901780ab9bb790cf35f79933c129071367a9242d7e1931709cddddc8ea028f6a74aae30468cce057943c8a92010e
+  languageName: node
+  linkType: hard
+
+"@smithy/eventstream-serde-universal@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@smithy/eventstream-serde-universal@npm:2.0.6"
+  dependencies:
+    "@smithy/eventstream-codec": ^2.0.6
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: 965916323341d73ee55bcaefbf545af8034056602344f25a93c2f4f9cbfa8f4f4ea17f1f1d34eb409e601692eb6711955d8d9015f7536dddde440eba6e75f00b
+  languageName: node
+  linkType: hard
+
+"@smithy/fetch-http-handler@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "@smithy/fetch-http-handler@npm:2.1.2"
+  dependencies:
+    "@smithy/protocol-http": ^3.0.2
+    "@smithy/querystring-builder": ^2.0.6
+    "@smithy/types": ^2.3.0
+    "@smithy/util-base64": ^2.0.0
+    tslib: ^2.5.0
+  checksum: fe16f3fdd825a10a808636e5c12e68d633e4cc1ed2d6a9339fedff4d7c72e2ca8704eb29823e980c3ba690bd510ff3f9db7f57ae35826fbe18c402f14342c195
+  languageName: node
+  linkType: hard
+
+"@smithy/hash-blob-browser@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@smithy/hash-blob-browser@npm:2.0.6"
+  dependencies:
+    "@smithy/chunked-blob-reader": ^2.0.0
+    "@smithy/chunked-blob-reader-native": ^2.0.0
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: 770a22456fe82aaf13b06194cf00a72a6d22caf311b8b81cf5d18b0c333320be0da34f4ceb5ae401a87c28e35ef663344031db91c2facd3ec84d37ea4a21c968
+  languageName: node
+  linkType: hard
+
+"@smithy/hash-node@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@smithy/hash-node@npm:2.0.6"
+  dependencies:
+    "@smithy/types": ^2.3.0
+    "@smithy/util-buffer-from": ^2.0.0
+    "@smithy/util-utf8": ^2.0.0
+    tslib: ^2.5.0
+  checksum: 9299995a7926d2aed8f375e12ba3745e964d3626754b3b754543fe4e40348366f2ead3e43fd55ab2c39303f62fa67c68f228feffb5fc8088567b9b3074662b7a
+  languageName: node
+  linkType: hard
+
+"@smithy/hash-stream-node@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@smithy/hash-stream-node@npm:2.0.6"
+  dependencies:
+    "@smithy/types": ^2.3.0
+    "@smithy/util-utf8": ^2.0.0
+    tslib: ^2.5.0
+  checksum: 2b20c06684d6b8b3d9685a4a48f52e985d0eea5996f7d788da8082a3f38fbe56e0140acae498f2a7d20695493a70f369d416fdddea4bbdaa5035c7d61e3d0314
+  languageName: node
+  linkType: hard
+
+"@smithy/invalid-dependency@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@smithy/invalid-dependency@npm:2.0.6"
+  dependencies:
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: 78d1ba3fc4640ffa5906547c8c7232eb25503bbd594d7199e183705adbc020c40a57bbb0846ffc629d83c9653beefcd17ee6015245124f77ed71dcbe443027a5
+  languageName: node
+  linkType: hard
+
+"@smithy/is-array-buffer@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@smithy/is-array-buffer@npm:2.0.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: 6d101cf509a7818667f42d297894f88f86ef41d3cc9d02eae38bbe5e69b16edf83b8e67eb691964d859a16a4e39db1aad323d83f6ae55ae4512a14ff6406c02d
+  languageName: node
+  linkType: hard
+
+"@smithy/md5-js@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@smithy/md5-js@npm:2.0.6"
+  dependencies:
+    "@smithy/types": ^2.3.0
+    "@smithy/util-utf8": ^2.0.0
+    tslib: ^2.5.0
+  checksum: de80f9da145610ddd58b9ee7f22b7450a57ea1db60a6b9db326cf3833f18482d6080dfdadaa89eaaaf4a68cd2c78bff25b664f36f2f8677602af644d49773a3f
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-content-length@npm:^2.0.8":
+  version: 2.0.8
+  resolution: "@smithy/middleware-content-length@npm:2.0.8"
+  dependencies:
+    "@smithy/protocol-http": ^3.0.2
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: ac22d3a83bd5a832190cdba58a2baedeccc94b015c7caad05e93209a4565e54e9085680d2f5fd4fd165d64fa465905bc79bb3c95dfc7b4a341d0f2ac3a0cb905
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-endpoint@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@smithy/middleware-endpoint@npm:2.0.6"
+  dependencies:
+    "@smithy/middleware-serde": ^2.0.6
+    "@smithy/types": ^2.3.0
+    "@smithy/url-parser": ^2.0.6
+    "@smithy/util-middleware": ^2.0.0
+    tslib: ^2.5.0
+  checksum: 7166db0fdec8dfc52409ee5779111858fbb3c6a606fe5aa1c438571eb57952493c9256656d1cf02683e20fed13e76e73131b59747f437e45962f0d82782bdd14
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-retry@npm:^2.0.9":
+  version: 2.0.9
+  resolution: "@smithy/middleware-retry@npm:2.0.9"
+  dependencies:
+    "@smithy/node-config-provider": ^2.0.9
+    "@smithy/protocol-http": ^3.0.2
+    "@smithy/service-error-classification": ^2.0.0
+    "@smithy/types": ^2.3.0
+    "@smithy/util-middleware": ^2.0.0
+    "@smithy/util-retry": ^2.0.0
+    tslib: ^2.5.0
+    uuid: ^8.3.2
+  checksum: 353168bf0640dfe27cbdf6ffd0f8f55a33454db4d9c4ef4a9a187c32cc8c36e3aa51d6d26ac8829a0d49760a1d8287d0445faeb739922cf1eed530fd24d4266f
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-serde@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@smithy/middleware-serde@npm:2.0.6"
+  dependencies:
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: e5b5c12dfdea74cf9dc7966c8611d73ba58d1941a5b82c9c0b86f9b9d95d7d9c09ccb4d14e8daedf80c99840cb5a35f99a8a54875b48497b1cae378ad9aa55a1
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-stack@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@smithy/middleware-stack@npm:2.0.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: dd23dff4da44964e936c5ae465de9416bb8dd67da2ae72ffe450156ad52e82475836ed5c18d82cef7edeca421b33d363889549e34482008eeb9ca0bb97f061f2
+  languageName: node
+  linkType: hard
+
+"@smithy/node-config-provider@npm:^2.0.9":
+  version: 2.0.9
+  resolution: "@smithy/node-config-provider@npm:2.0.9"
+  dependencies:
+    "@smithy/property-provider": ^2.0.7
+    "@smithy/shared-ini-file-loader": ^2.0.8
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: f942c02280b347e69fceb3c0fe39f0651cc10fec078b8d5176b588fc19cfa7f686b7fe0b27b359704ee7542b4a6f523f331eea44d9c2024a2027f44dfce750fe
+  languageName: node
+  linkType: hard
+
+"@smithy/node-http-handler@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "@smithy/node-http-handler@npm:2.1.2"
+  dependencies:
+    "@smithy/abort-controller": ^2.0.6
+    "@smithy/protocol-http": ^3.0.2
+    "@smithy/querystring-builder": ^2.0.6
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: eac05cd0dfc4d1a70c569b922cd5c7769bb44225cf351c95ba9624a4f57f0183b53279522405982c3f3ac07458ee31894c988a7e19d34ccb30058392cb6b7cae
+  languageName: node
+  linkType: hard
+
+"@smithy/property-provider@npm:^2.0.0, @smithy/property-provider@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "@smithy/property-provider@npm:2.0.7"
+  dependencies:
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: fc95e5909c468697fc12ac0027e45274be1ed8a980776ec0b2bb58245ede0c6dbd133d4b62e29ac37b08c965495bd212f29fc6483ca535e87686b65072ef4fb4
+  languageName: node
+  linkType: hard
+
+"@smithy/protocol-http@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "@smithy/protocol-http@npm:3.0.2"
+  dependencies:
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: 0e4b25fdcd2736a0bcd14800eb731d85b01b04fb1b7171e6eeef628560cc6acdb4a8478d4acba53daa2b5845e49a019781b31609a0b40181a2f44ad8ece606d6
+  languageName: node
+  linkType: hard
+
+"@smithy/querystring-builder@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@smithy/querystring-builder@npm:2.0.6"
+  dependencies:
+    "@smithy/types": ^2.3.0
+    "@smithy/util-uri-escape": ^2.0.0
+    tslib: ^2.5.0
+  checksum: 2204468dca7f039afe99cc37f2ec9804fc714bd9076911ade8cbd59c5d3cfe1d8e0073125dbf15eb1d1f96cfbc34dd889a941ab80dd02d0f1c4613c40526839a
+  languageName: node
+  linkType: hard
+
+"@smithy/querystring-parser@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@smithy/querystring-parser@npm:2.0.6"
+  dependencies:
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: 93a3969c7c8cc5849c3625c1ace66459a8cd15f9bcd48dc12d6afd7af21860d8f5db50a7cc7d39d3f34bd42d5b3b34f7e06bf430705fb8c6e2053f8f258092ba
+  languageName: node
+  linkType: hard
+
+"@smithy/service-error-classification@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@smithy/service-error-classification@npm:2.0.0"
+  checksum: f6f9b869dca8e74871c428e1277dd3700f67b0ca61de69fc838ac55187bbc602193a7d1073113ea6916892babf3f8fe4938b182fc902ce0a415928799a7e3f9a
+  languageName: node
+  linkType: hard
+
+"@smithy/shared-ini-file-loader@npm:^2.0.6, @smithy/shared-ini-file-loader@npm:^2.0.8":
+  version: 2.0.8
+  resolution: "@smithy/shared-ini-file-loader@npm:2.0.8"
+  dependencies:
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: d08a0ffe020f606d48bf98e40b84ecf36f765a2f78f378f36339b68016f25794b4534955bcd2f786c4b61d49d7339ea29778bc0bf26d7c9583b480ee68998784
+  languageName: node
+  linkType: hard
+
+"@smithy/signature-v4@npm:^2.0.0":
+  version: 2.0.6
+  resolution: "@smithy/signature-v4@npm:2.0.6"
+  dependencies:
+    "@smithy/eventstream-codec": ^2.0.6
+    "@smithy/is-array-buffer": ^2.0.0
+    "@smithy/types": ^2.3.0
+    "@smithy/util-hex-encoding": ^2.0.0
+    "@smithy/util-middleware": ^2.0.0
+    "@smithy/util-uri-escape": ^2.0.0
+    "@smithy/util-utf8": ^2.0.0
+    tslib: ^2.5.0
+  checksum: d916be5fecb6d8f2534c4ac1e4a90aec8b66392b593d34c070d95089d4fd7b30356af64de7bb0d6c6dda75e22e5042870fa66143fc38c0d39987f60562b65123
+  languageName: node
+  linkType: hard
+
+"@smithy/smithy-client@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "@smithy/smithy-client@npm:2.1.3"
+  dependencies:
+    "@smithy/middleware-stack": ^2.0.0
+    "@smithy/types": ^2.3.0
+    "@smithy/util-stream": ^2.0.9
+    tslib: ^2.5.0
+  checksum: eba7a375fcc0dfb23e5b898389254a7c13b1f40bc686ad785e291651fa945c44d6ba499fed1cbe37b6fc79a9810c9b6ef83121e86e00ed95bc9522dfb0fdb90b
+  languageName: node
+  linkType: hard
+
+"@smithy/types@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "@smithy/types@npm:2.3.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: c0195be70fed780cd3063d54481b7393eec9d229c49aa05da76570a8ad1eb2478888700fbb5f004c38ce6b1c99175898639225a44c0dc474419524f4d62b8bb4
+  languageName: node
+  linkType: hard
+
+"@smithy/url-parser@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@smithy/url-parser@npm:2.0.6"
+  dependencies:
+    "@smithy/querystring-parser": ^2.0.6
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: 62fd2eb12abb514c1da9a10d20d01a6171e81a57382c87e5731b75a9a4c40ed11d467145c0802544a95372ec1a55a9317389b64de8b4628e77210dd2ddf0e7ce
+  languageName: node
+  linkType: hard
+
+"@smithy/util-base64@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@smithy/util-base64@npm:2.0.0"
+  dependencies:
+    "@smithy/util-buffer-from": ^2.0.0
+    tslib: ^2.5.0
+  checksum: 52124a684dfac853288acd2a0ffff02559c21bf7faaa3db58a914e4acb4b1f7925fd48593e7545db87f8f962250824d1249dc8be645ecbd2c1dd1728cfe1069b
+  languageName: node
+  linkType: hard
+
+"@smithy/util-body-length-browser@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@smithy/util-body-length-browser@npm:2.0.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: 4bccdd857bd24c9dcb6e9f2d5be03d59415f9a94d660ec7b3efb45e9aa04017f34c387368f176f24233a071af3b7a2b5f8236a2f5a83bfc884d24dfcc341e836
+  languageName: node
+  linkType: hard
+
+"@smithy/util-body-length-node@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@smithy/util-body-length-node@npm:2.1.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: e4635251898f12e1825f2848e0b7cc9d01ec6635b3f1f71b790734bb702b88e795f6c539d42d95472dad00e50e9ff13fcf396791092b131e5834069cb8f52ed0
+  languageName: node
+  linkType: hard
+
+"@smithy/util-buffer-from@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@smithy/util-buffer-from@npm:2.0.0"
+  dependencies:
+    "@smithy/is-array-buffer": ^2.0.0
+    tslib: ^2.5.0
+  checksum: d33cbf3e488d23390c88705ddae71b08de7a87b6453e38b508cd37a22a02e8b5be9f0cd46c1347b496c3977a815a7399b18840544ecdc4cce8cf3dcd0f5bb009
+  languageName: node
+  linkType: hard
+
+"@smithy/util-config-provider@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@smithy/util-config-provider@npm:2.0.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: cdc34db5b42658a7c98652ddb2e35b31e0d76f22a051d71724927999a53467fb38fe6dcf228585544bc168cbd54ded3913e14cbc33c947d3c8a45ca518a9b7b0
+  languageName: node
+  linkType: hard
+
+"@smithy/util-defaults-mode-browser@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "@smithy/util-defaults-mode-browser@npm:2.0.7"
+  dependencies:
+    "@smithy/property-provider": ^2.0.7
+    "@smithy/types": ^2.3.0
+    bowser: ^2.11.0
+    tslib: ^2.5.0
+  checksum: 956e276d66fea4b9c469c13f2d7cad61386e1f9dc86751ff1d069288c928a7f7bba248a77394c0f38864c9904fe7b6a98beae16b12ddc8c6e207fa0a00386048
+  languageName: node
+  linkType: hard
+
+"@smithy/util-defaults-mode-node@npm:^2.0.9":
+  version: 2.0.9
+  resolution: "@smithy/util-defaults-mode-node@npm:2.0.9"
+  dependencies:
+    "@smithy/config-resolver": ^2.0.7
+    "@smithy/credential-provider-imds": ^2.0.9
+    "@smithy/node-config-provider": ^2.0.9
+    "@smithy/property-provider": ^2.0.7
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: a92e55de2d1adbdaf126c20b02ebdb1a919a3fe8cc9ab21346c4f082e3bc43010bc3eb889e754821279571b93da4050bdde1ab877715a5db8ed30bb860ef332e
+  languageName: node
+  linkType: hard
+
+"@smithy/util-hex-encoding@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@smithy/util-hex-encoding@npm:2.0.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: 884373e089d909e3c9805bdb78f367d1f3612e4e1e6d8f0263cc82a8b9689eddc0bc80b8b58aa711bd5b48d9cb124f9996906c172e951c9dac78984459e831cf
+  languageName: node
+  linkType: hard
+
+"@smithy/util-middleware@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@smithy/util-middleware@npm:2.0.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: 10401734a10e0c48ed684f20b7a34c40ed85f2e906e61adb6295963d035f2a93b524e80149a252a259a4bca3626773bf89c5eaa2423fd565358c6b4eb9b6d4e0
+  languageName: node
+  linkType: hard
+
+"@smithy/util-retry@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@smithy/util-retry@npm:2.0.0"
+  dependencies:
+    "@smithy/service-error-classification": ^2.0.0
+    tslib: ^2.5.0
+  checksum: d5bfe5e81f41dffce6ba5aaf784f08247602d00f883c10c0de9e34a7f04f5369d7ac43901dd75eecc3864882b7390ad40885d07b3dcb35a366411b639482e673
+  languageName: node
+  linkType: hard
+
+"@smithy/util-stream@npm:^2.0.9":
+  version: 2.0.9
+  resolution: "@smithy/util-stream@npm:2.0.9"
+  dependencies:
+    "@smithy/fetch-http-handler": ^2.1.2
+    "@smithy/node-http-handler": ^2.1.2
+    "@smithy/types": ^2.3.0
+    "@smithy/util-base64": ^2.0.0
+    "@smithy/util-buffer-from": ^2.0.0
+    "@smithy/util-hex-encoding": ^2.0.0
+    "@smithy/util-utf8": ^2.0.0
+    tslib: ^2.5.0
+  checksum: 54e0f49717cdd0bb8fec3e8ba4275eedaff30aa9bacdb68999a49956720138282cb90e89e39f7f7b173c4b593670241f44d2db1a3a4a15062bd3afe869624945
+  languageName: node
+  linkType: hard
+
+"@smithy/util-uri-escape@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@smithy/util-uri-escape@npm:2.0.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: d201cee524ece997c406902463b5ea0b72599994f7b3ac1d923d5645497e9ef93126d146016f13dd4afafe33b9a3e92faf4e023cf0af510b270c1b9ce3d78da8
+  languageName: node
+  linkType: hard
+
+"@smithy/util-utf8@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@smithy/util-utf8@npm:2.0.0"
+  dependencies:
+    "@smithy/util-buffer-from": ^2.0.0
+    tslib: ^2.5.0
+  checksum: bc8cda84f85b513380a61352635b306ae50d3b92974454db32835b39bbaa38150332b89346098ba9dea2e0002e2963fcbdd622bc9b3eec7b7ea8fa3f8c7ce737
+  languageName: node
+  linkType: hard
+
+"@smithy/util-waiter@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@smithy/util-waiter@npm:2.0.6"
+  dependencies:
+    "@smithy/abort-controller": ^2.0.6
+    "@smithy/types": ^2.3.0
+    tslib: ^2.5.0
+  checksum: d38e5d9fe06fe41ee24aaea53df71161715b218c2acf81431e92847b30db053316dac3047e7f2e9bd42c4b434ed5efbcce83167769b9a24dae9ea2cf9abd07c3
+  languageName: node
+  linkType: hard
+
 "@tanstack/match-sorter-utils@npm:^8.7.0":
   version: 8.8.4
   resolution: "@tanstack/match-sorter-utils@npm:8.8.4"
@@ -2539,7 +3710,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/multer@npm:^1.4.7":
+"@types/multer-s3@npm:^3":
+  version: 3.0.0
+  resolution: "@types/multer-s3@npm:3.0.0"
+  dependencies:
+    "@aws-sdk/client-s3": ^3.0.0
+    "@types/multer": "*"
+  checksum: 948b75ee95b0007aeca9c975ecda0ae18a3869b9da60ac7661fbdd7f80da493cef5c2268162ff12ec6e4f4e0dbb16ad28811a2124284ccdf57e5751f32b31074
+  languageName: node
+  linkType: hard
+
+"@types/multer@npm:*, @types/multer@npm:^1.4.7":
   version: 1.4.7
   resolution: "@types/multer@npm:1.4.7"
   dependencies:
@@ -3578,7 +4759,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base64-js@npm:^1.3.1":
+"base64-js@npm:^1.0.2, base64-js@npm:^1.3.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
   checksum: 669632eb3745404c2f822a18fc3a0122d2f9a7a13f7fb8b5823ee19d1d2ff9ee5b52c53367176ea4ad093c332fd5ab4bd0ebae5a8e27917a4105a4cfc86b1005
@@ -3657,6 +4838,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bowser@npm:^2.11.0":
+  version: 2.11.0
+  resolution: "bowser@npm:2.11.0"
+  checksum: 29c3f01f22e703fa6644fc3b684307442df4240b6e10f6cfe1b61c6ca5721073189ca97cdeedb376081148c8518e33b1d818a57f781d70b0b70e1f31fb48814f
+  languageName: node
+  linkType: hard
+
 "brace-expansion@npm:^1.1.7":
   version: 1.1.11
   resolution: "brace-expansion@npm:1.1.11"
@@ -3728,6 +4916,16 @@ __metadata:
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
   checksum: 0448524a562b37d4d7ed9efd91685a5b77a50672c556ea254ac9a6d30e3403a517d8981f10e565db24e8339413b43c97ca2951f10e399c6125a0d8911f5679bb
+  languageName: node
+  linkType: hard
+
+"buffer@npm:5.6.0":
+  version: 5.6.0
+  resolution: "buffer@npm:5.6.0"
+  dependencies:
+    base64-js: ^1.0.2
+    ieee754: ^1.1.4
+  checksum: d659494c5032dd39d03d2912e64179cc44c6340e7e9d1f68d3840e7ab4559989fbce92b4950174593c38d05268224235ba404f0878775cab2a616b6dcad9c23e
   languageName: node
   linkType: hard
 
@@ -5141,7 +6339,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"events@npm:^3.2.0":
+"events@npm:3.3.0, events@npm:^3.2.0":
   version: 3.3.0
   resolution: "events@npm:3.3.0"
   checksum: f6f487ad2198aa41d878fa31452f1a3c00958f46e9019286ff4787c84aac329332ab45c9cdc8c445928fc6d7ded294b9e005a7fce9426488518017831b272780
@@ -5341,6 +6539,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-xml-parser@npm:4.2.5":
+  version: 4.2.5
+  resolution: "fast-xml-parser@npm:4.2.5"
+  dependencies:
+    strnum: ^1.0.5
+  bin:
+    fxparser: src/cli/cli.js
+  checksum: d32b22005504eeb207249bf40dc82d0994b5bb9ca9dcc731d335a1f425e47fe085b3cace3cf9d32172dd1a5544193c49e8615ca95b4bf95a4a4920a226b06d80
+  languageName: node
+  linkType: hard
+
 "fastest-levenshtein@npm:^1.0.12":
   version: 1.0.16
   resolution: "fastest-levenshtein@npm:1.0.16"
@@ -5393,6 +6602,13 @@ __metadata:
   peerDependencies:
     webpack: ^4.0.0 || ^5.0.0
   checksum: faf43eecf233f4897b0150aaa874eeeac214e4f9de49738a9e0ef734a30b5260059e85b7edadf852b98e415f875bd5f12587768a93fd52aaf2e479ecf95fab20
+  languageName: node
+  linkType: hard
+
+"file-type@npm:^3.3.0":
+  version: 3.9.0
+  resolution: "file-type@npm:3.9.0"
+  checksum: 1db70b2485ac77c4edb4b8753c1874ee6194123533f43c2651820f96b518f505fa570b093fedd6672eb105ba9fb89c62f84b6492e46788e39c3447aed37afa2d
   languageName: node
   linkType: hard
 
@@ -5987,6 +7203,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"html-comment-regex@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "html-comment-regex@npm:1.1.2"
+  checksum: 64c1e13c93f91554a06327176663037e630f5a47de8aae6a6a60cbca25e6d7b63ee16dd35707e33ba09288b900c6947050c6945c34a0a84d27f5415cef525599
+  languageName: node
+  linkType: hard
+
 "html-escaper@npm:^2.0.0":
   version: 2.0.2
   resolution: "html-escaper@npm:2.0.2"
@@ -6145,7 +7368,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ieee754@npm:^1.1.13":
+"ieee754@npm:^1.1.13, ieee754@npm:^1.1.4":
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
   checksum: 5144c0c9815e54ada181d80a0b810221a253562422e7c6c3a60b1901154184f49326ec239d618c416c1c5945a2e197107aee8d986a3dd836b53dffefd99b5e7e
@@ -6205,7 +7428,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.3":
+"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.3, inherits@npm:~2.0.4":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 4a48a733847879d6cf6691860a6b1e3f0f4754176e4d71494c41f3475553768b10f84b5ce1d40fbd0e34e6bfbb864ee35858ad4dd2cf31e02fc4a154b724d7f1
@@ -7884,6 +9107,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"multer-s3@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "multer-s3@npm:3.0.1"
+  dependencies:
+    "@aws-sdk/lib-storage": ^3.46.0
+    file-type: ^3.3.0
+    html-comment-regex: ^1.1.2
+    run-parallel: ^1.1.6
+  peerDependencies:
+    "@aws-sdk/client-s3": ^3.0.0
+  checksum: 376b832c9f124db80051de5b4d637120d49f569614a5da6333c5903e3c6299e6210bc4e140485b4c6becb884792cc0b1f29da0d06731116b1518b46c4a89cdf6
+  languageName: node
+  linkType: hard
+
 "multer@npm:1.4.4-lts.1":
   version: 1.4.4-lts.1
   resolution: "multer@npm:1.4.4-lts.1"
@@ -9018,7 +10255,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.0":
+"readable-stream@npm:^3.4.0, readable-stream@npm:^3.5.0, readable-stream@npm:^3.6.0":
   version: 3.6.2
   resolution: "readable-stream@npm:3.6.2"
   dependencies:
@@ -9324,7 +10561,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"run-parallel@npm:^1.1.9":
+"run-parallel@npm:^1.1.6, run-parallel@npm:^1.1.9":
   version: 1.2.0
   resolution: "run-parallel@npm:1.2.0"
   dependencies:
@@ -9481,6 +10718,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "server@workspace:packages/server"
   dependencies:
+    "@aws-sdk/client-s3": ^3.410.0
     "@nestjs/cli": ^9.0.0
     "@nestjs/common": ^9.0.0
     "@nestjs/config": ^3.0.0
@@ -9497,6 +10735,7 @@ __metadata:
     "@types/express-session": ^1.17.7
     "@types/jest": ^29.5.3
     "@types/multer": ^1.4.7
+    "@types/multer-s3": ^3
     "@types/node": 18.16.12
     "@types/node-fetch": ^2.6.4
     "@types/passport-local": ^1.0.35
@@ -9514,6 +10753,7 @@ __metadata:
     express-session: ^1.17.3
     jest: ^29.6.1
     mongoose: ^7.4.3
+    multer-s3: ^3.0.1
     node-fetch: 2
     passport: ^0.6.0
     passport-local: ^1.0.0
@@ -9777,6 +11017,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stream-browserify@npm:3.0.0":
+  version: 3.0.0
+  resolution: "stream-browserify@npm:3.0.0"
+  dependencies:
+    inherits: ~2.0.4
+    readable-stream: ^3.5.0
+  checksum: 4c47ef64d6f03815a9ca3874e2319805e8e8a85f3550776c47ce523b6f4c6cd57f40e46ec6a9ab8ad260fde61863c2718f250d3bedb3fe9052444eb9abfd9921
+  languageName: node
+  linkType: hard
+
 "streamsearch@npm:^1.1.0":
   version: 1.1.0
   resolution: "streamsearch@npm:1.1.0"
@@ -9940,6 +11190,13 @@ __metadata:
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
   checksum: 492f73e27268f9b1c122733f28ecb0e7e8d8a531a6662efbd08e22cccb3f9475e90a1b82cab06a392f6afae6d2de636f977e231296400d0ec5304ba70f166443
+  languageName: node
+  linkType: hard
+
+"strnum@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "strnum@npm:1.0.5"
+  checksum: 651b2031db5da1bf4a77fdd2f116a8ac8055157c5420f5569f64879133825915ad461513e7202a16d7fec63c54fd822410d0962f8ca12385c4334891b9ae6dd2
   languageName: node
   linkType: hard
 
@@ -10368,7 +11625,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.8.1":
+"tslib@npm:^1.11.1, tslib@npm:^1.8.1":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
@@ -10379,6 +11636,13 @@ __metadata:
   version: 2.6.0
   resolution: "tslib@npm:2.6.0"
   checksum: c01066038f950016a18106ddeca4649b4d76caa76ec5a31e2a26e10586a59fceb4ee45e96719bf6c715648e7c14085a81fee5c62f7e9ebee68e77a5396e5538f
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.3.1, tslib@npm:^2.5.0":
+  version: 2.6.2
+  resolution: "tslib@npm:2.6.2"
+  checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad
   languageName: node
   linkType: hard
 
@@ -10496,11 +11760,11 @@ __metadata:
 
 "typescript@patch:typescript@4.9.5#~builtin<compat/typescript>":
   version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=23ec76"
+  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=289587"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: ab417a2f398380c90a6cf5a5f74badd17866adf57f1165617d6a551f059c3ba0a3e4da0d147b3ac5681db9ac76a303c5876394b13b3de75fdd5b1eaa06181c9d
+  checksum: 1f8f3b6aaea19f0f67cba79057674ba580438a7db55057eb89cc06950483c5d632115c14077f6663ea76fd09fce3c190e6414bb98582ec80aa5a4eaf345d5b68
   languageName: node
   linkType: hard
 
@@ -10656,6 +11920,15 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 8dd2c83c43ddc7e1c71e36b60aea40030a6505139af6bee0f382ebcd1a56f6cd3028f7f06ffb07f8cf6ced320b76aea275284b224b002b289f89fe89c389b028
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^8.3.2":
+  version: 8.3.2
+  resolution: "uuid@npm:8.3.2"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### 이 PR 이 머지되면, env 에 AWS_S3_REGION, AWS_S3_BUCKET, AWS_S3_ACCESS_KEY_ID, AWS_S3_SECRET_ACCESS_KEY 이 추가되어야 합니다

### 이 PR 머지 후 현재 올라간 데이터를 클리닝 할 예정입니다.

- 서버에 올라간 shop-list 는 DB 에 저장되나 이미지의 경우 로컬에 저장되고있기 때문에, 로컬에서 작업한 내용은 DB 에 데이터가 올라갔지만 이미지를 찾을 수 없게 됩니다
- 둘 다 로컬이 아닌 인프라에 두기 위해 AWS S3 를 택했으며, 이제 로컬과 서버환경 둘 다 데이터를 올린 경우 정상적으로 보이게 됩니다
- 또한 이미지의 경로가 https://resources.run-eat.com/ 로 시작하게 됩니다
