### PR TITLE
feat: Shop 을 외부에 리스팅 제공할때는 가공된 데이터를 보여준다

### DIFF
--- a/packages/client/src/components/common/ErrorFallback.jsx
+++ b/packages/client/src/components/common/ErrorFallback.jsx
@@ -3,17 +3,17 @@ import runeat from '../../../public/images/run_eat01.png';
 
 const getErrorMessage = (status) => {
   switch (status) {
-    case 403:
-      return {
-        title: '데이터를 불러오는데 실패하였습니다.',
-        content: '다시 시도 해주세요.',
-      };
-    case 409:
-    case 500:
-      return {
-        title: '서비스에 접속할 수 없습니다.',
-        content: '새로고침을 하거나 잠시 후 다시 접속해 주시기 바랍니다.',
-      };
+  case 403:
+    return {
+      title: '데이터를 불러오는데 실패하였습니다.',
+      content: '다시 시도 해주세요.',
+    };
+  case 409:
+  case 500:
+    return {
+      title: '서비스에 접속할 수 없습니다.',
+      content: '새로고침을 하거나 잠시 후 다시 접속해 주시기 바랍니다.',
+    };
   }
 };
 

--- a/packages/client/src/components/search/Searchbox.jsx
+++ b/packages/client/src/components/search/Searchbox.jsx
@@ -15,7 +15,7 @@ export default function Searchbox(){
     } else {
       navigate(`/search?keyword=${trimmedKeyword}`);
     }
-  }
+  };
   
   return (
     <section className='relative h-[340px]'>

--- a/packages/client/src/components/shop/ShopListItem.jsx
+++ b/packages/client/src/components/shop/ShopListItem.jsx
@@ -16,7 +16,7 @@ export default function ShopListItem({ shop }) {
 
   const handleLike = () => {
     setLiked(!liked);
-  }
+  };
 
   return (
     <li>

--- a/packages/client/src/pages/ProtectedRoute.jsx
+++ b/packages/client/src/pages/ProtectedRoute.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useCheckLogin } from '../hooks/auth/useUser';
 

--- a/packages/server/src/modules/shop/dto/home-shop-item.dto.ts
+++ b/packages/server/src/modules/shop/dto/home-shop-item.dto.ts
@@ -1,0 +1,30 @@
+import { Shop } from '../../../schemas/shop.schema';
+import { FoodTypes, PriceRanges } from '../../../constants/shop';
+import { calculateAverage } from '../../../utils/number';
+import { get } from '../../../utils/object';
+
+export class HomeShopItemDto implements Partial<Shop> {
+  title: string;
+  type: keyof typeof FoodTypes;
+  priceRange: keyof typeof PriceRanges;
+  tags: string[];
+  rating: number;
+  ratingCount: number;
+  imageUrl: string;
+  isFavorite: boolean;
+}
+
+export function toHomeShopItemDto<T extends Shop>(model: T) {
+  const dto = new HomeShopItemDto();
+  dto.title = model.title;
+  dto.type = model.type;
+  dto.priceRange = model.priceRange;
+  dto.tags = model.tags;
+  dto.rating = model.reviews?.length
+    ? +calculateAverage(model.reviews.map(get('rating'))).toFixed(1)
+    : 0;
+  dto.ratingCount = model.reviews?.length || 0;
+  dto.imageUrl = model.imageUrls[0];
+  dto.isFavorite = false; // TODO
+  return dto;
+}

--- a/packages/server/src/modules/shop/shop.service.ts
+++ b/packages/server/src/modules/shop/shop.service.ts
@@ -5,6 +5,7 @@ import { validateOrReject } from 'class-validator';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { Shop } from '../../schemas/shop.schema';
+import { toHomeShopItemDto } from './dto/home-shop-item.dto';
 
 @Injectable()
 export class ShopService {
@@ -21,16 +22,19 @@ export class ShopService {
     await this.shopModel.findByIdAndUpdate(id, updateShopDto);
   }
 
-  find(keyword?: string) {
+  async find(keyword?: string) {
     if (keyword) {
       const sanitizedKeyword = keyword.replace(/[#-.]|[[-^]|[?|{}]/g, '\\$&');
-      return this.shopModel.find({ title: { $regex: sanitizedKeyword } });
+      const models = await this.shopModel.find({
+        title: { $regex: sanitizedKeyword },
+      });
+      return models.map(toHomeShopItemDto);
     }
-    return this.shopModel.find().exec();
+    return (await this.shopModel.find()).map(toHomeShopItemDto);
   }
 
-  findOne(id: string) {
-    return this.shopModel.findById(id);
+  async findOne(id: string) {
+    return toHomeShopItemDto(await this.shopModel.findById(id));
   }
 
   remove(id: number) {

--- a/packages/server/src/utils/number.ts
+++ b/packages/server/src/utils/number.ts
@@ -1,0 +1,7 @@
+export const sum = (args: number[]) => {
+  return args.reduce((result, arg) => result + arg, 0);
+};
+
+export const calculateAverage = (args: number[]) => {
+  return sum(args) / args.length;
+};

--- a/packages/server/src/utils/object.ts
+++ b/packages/server/src/utils/object.ts
@@ -1,0 +1,4 @@
+export const get =
+  <T>(property: keyof T) =>
+  (obj: T) =>
+    obj[property];


### PR DESCRIPTION
- 로컬에서 커밋하면 린트가 자동처리되어서, 그 부분도 같이 커밋올렸습니다
- ShopService 에서 리스트 요청을 받으면, 모든 DB 모델은 HomeShopItemDto 로 가공되어서 나갑니다. 그러므로 packages/server/src/modules/shop/dto/home-shop-item.dto.ts 의 프로퍼티가 클라이언트로 나간다고 보시면 됩니다

- rating 과 rating count 가 따로 내려가는데요, 만약 그렇지 않다면 rating 계산 결과를 내려주지 않고, 리뷰점수들을 클라에게 그대로 내려주고 클라가 계산하는 방법도 있습니다. 어떤게 더 좋을까요?